### PR TITLE
Enhance cli arguments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,19 +7,19 @@ use clap::Parser;
 #[command(version = "1.0")]
 #[command(about = "sniffs flat files", long_about = None)]
 pub struct Args {
-    #[arg(long)]
+    #[arg(long, short='f')]
     file_path: String,
 
-    #[arg(long)]
+    #[arg(long, short='d')]
     delimiter: String,
 
-    #[arg(long, default_value_t = 0)]
+    #[arg(long,short='q', default_value_t = 1)]
     quote: u32,
 
-    #[arg(long, default_value_t = 1)]
+    #[arg(long, short='n', default_value_t = 1)]
     check_nulls: u32,
 
-    #[arg(long, default_value_t = 1)]
+    #[arg(long, short='w', default_value_t = 1)]
     check_whitespace: u32,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,23 +54,31 @@ impl Args {
 
 
 
-
-pub fn get_file_size_in_mb(file_path: &str) -> f64 {
-    let metadata: fs::Metadata = fs::metadata(file_path).expect("Error reading file metadata");
+/// Get a file size in MB
+/// 
+/// # Arguments
+/// 
+/// * `file_path` - A string slice that holds the path to the file
+/// 
+/// # Returns
+/// Result<f64, Box<dyn Error>> - A result that is either a file size  or an error message
+/// 
+pub fn get_file_size_in_mb(file_path: &str) -> Result<f64, Box<dyn Error>> {
+    let metadata: fs::Metadata = fs::metadata(file_path)?;
     let file_size: f64 = metadata.len() as f64;
     let mb_size: f64 = file_size / (1024.0 * 1024.0);
-    mb_size
+    Ok(mb_size)
 }
 
-// check whitespace at beginning or end of string
-// 
-// # Arguments
-//
-// * `s` - A string slice that we want to check for whitespace at beginning or end
-//
-// # Returns
-//
-// * `Result<bool, &'static str>` - A result that is either a boolean or an error message
+/// check whitespace at beginning or end of string
+/// 
+/// # Arguments
+///
+///  * `s` - A string slice that we want to check for whitespace at beginning or end
+///
+///  # Returns
+///
+/// * `Result<bool, &'static str>` - A result that is either a boolean or an error message
 fn has_whitespace_at_beginning_or_end(s: &str) -> Result<bool,&'static str> {
 
     if s.len() == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ impl Args {
 /// * `file_path` - A string slice that holds the path to the file
 /// 
 /// # Returns
-/// Result<f64, Box<dyn Error>> - A result that is either a file size  or an error message
+/// * Result<f64, Box<dyn Error>> - A result that is either a file size  or an error message
 /// 
 pub fn get_file_size_in_mb(file_path: &str) -> Result<f64, Box<dyn Error>> {
     let metadata: fs::Metadata = fs::metadata(file_path)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub struct Args {
     #[arg(long, short='d')]
     delimiter: String,
 
-    #[arg(long,short='q', default_value_t = 1)]
+    #[arg(long,short='q', default_value_t = 0)]
     quote: u32,
 
     #[arg(long, short='n', default_value_t = 1)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::process;
+
 use sniffer::*;
 
 
@@ -10,7 +12,11 @@ fn main() {
         sniffer::check_all_column_for_nulls_and_whitespace(&args);
     }
     
-    let size_in_mb = sniffer::get_file_size_in_mb(&args.file_path());
+    let size_in_mb = sniffer::get_file_size_in_mb(&args.file_path()).unwrap_or_else(|err|
+    {
+        println!("Error getting file size: {}", err);
+        process::exit(1);
+    } );
     
     println!("File size in MB: {}", size_in_mb);
 }


### PR DESCRIPTION
### Details

- Updating the CLI Arguments names to accept short hand letters to simplify using the library
- Enhance error handling in the function `get_file_size_in_mb`, it is now returning a `Result` `Result<f64, Box<dyn Error>>`.


### Code example(s)
```rust

#[arg(long, short='f')]
    file_path: String,

    #[arg(long, short='d')]
    delimiter: String,

    #[arg(long,short='q', default_value_t = 0)]
    quote: u32,

    #[arg(long, short='n', default_value_t = 1)]
    check_nulls: u32,

    #[arg(long, short='w', default_value_t = 1)]
    check_whitespace: u32,

``` 

```rust

pub fn get_file_size_in_mb(file_path: &str) -> Result<f64, Box<dyn Error>> {
    let metadata: fs::Metadata = fs::metadata(file_path)?;
    let file_size: f64 = metadata.len() as f64;
    let mb_size: f64 = file_size / (1024.0 * 1024.0);
    Ok(mb_size)
}

```


 