### PR TITLE
Enhance the delimiters' functionality

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub struct Args {
     #[arg(long, short='f')]
     file_path: String,
 
-    #[arg(long, short='d')]
+    #[arg(long, short='d', default_value_t = String::from(","))]
     delimiter: String,
 
     #[arg(long,short='q', default_value_t = 0)]
@@ -98,10 +98,19 @@ fn has_whitespace_at_beginning_or_end(s: &str) -> Result<bool,&'static str> {
 }
 
 pub fn check_all_column_for_nulls_and_whitespace(args:&Args) {
-    let file: fs::File = std::fs::File::open(args.file_path()).unwrap();
+    let file: fs::File = get_file_handler(args.file_path()).unwrap();
     let bf: BufReader<fs::File> = BufReader::new(file);
+
+    // get delimiter byte
+    // Allow support for future delimiters 
+    let delimiter_byte = match args.delimiter() {
+        "," => b',',
+        "\t" => b'\t',
+        _ => b',',
+    };
+    
     let mut rdr: csv::Reader<BufReader<fs::File>> = csv::ReaderBuilder::new()
-        .delimiter(if args.delimiter() == "," { b',' } else { b'\t' })
+        .delimiter( delimiter_byte )
         .double_quote(match args.quote() == &1 {
             true => true,
             false => false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,4 +263,17 @@ mod tests {
         let _result: fs::File = get_file_handler(file_path).unwrap();
     }
 
+    #[test]
+    fn test_delimiter_without_default_is_tab() {
+        let args: Args = Args::parse_from(&["sniffer", "-f", "test.csv", "-d", "\t"]);
+        let result: &str = args.delimiter();
+        assert_eq!(result, "\t");
+    }
+
+    #[test]
+    fn test_delimiter_with_default_is_comma() {
+        let args: Args = Args::parse_from(&["sniffer", "-f", "test.csv"]);
+        let result: &str = args.delimiter();
+        assert_eq!(result, ",");
+    }
 }


### PR DESCRIPTION
### Description
- Defining the `,` as the default value for the delimiters
- The delimiter argument is now optional, only the file argument is required
- Enhancing the delimiter conversion to bytes using the `match` to allow pattern matching and future support for different delimiter types
- Adding unit tests to test the delimiter part

### Notes
- No breaking changes introduced

### Code snippet 

```RUST

// get delimiter byte
    // Allow support for future delimiters 
    let delimiter_byte = match args.delimiter() {
        "," => b',',
        "\t" => b'\t',
        _ => b',',
    };

```


```RUST


    #[test]
    fn test_delimiter_without_default_is_tab() {
        let args: Args = Args::parse_from(&["sniffer", "-f", "test.csv", "-d", "\t"]);
        let result: &str = args.delimiter();
        assert_eq!(result, "\t");
    }

    #[test]
    fn test_delimiter_with_default_is_comma() {
        let args: Args = Args::parse_from(&["sniffer", "-f", "test.csv"]);
        let result: &str = args.delimiter();
        assert_eq!(result, ",");
    }

```