### PR TITLE
Enhance double quote getter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,4 +274,19 @@ mod tests {
         let result: &str = args.delimiter();
         assert_eq!(result, ",");
     }
+
+    #[test]
+    fn test_quote_with_default_is_false() {
+        let args: Args = Args::parse_from(&["sniffer", "-f", "test.csv"]);
+        let result: bool = args.quote();
+        assert_eq!(result, false);
+    }
+
+    #[test]
+    fn test_quote_with_true_is_true() {
+        let args: Args = Args::parse_from(&["sniffer", "-f", "test.csv", "-q", "1"]);
+        let result: bool = args.quote();
+        assert_eq!(result, true);
+    }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,12 @@ impl Args {
         &self.delimiter
     }
 
-    pub fn quote(&self) -> &u32 {
-        &self.quote
+    pub fn quote(&self) -> bool {
+        if &self.quote == &1 {
+            return true
+        } 
+
+        false
     }
 
     pub fn check_nulls(&self) -> &u32 {
@@ -111,10 +115,7 @@ pub fn check_all_column_for_nulls_and_whitespace(args:&Args) {
     
     let mut rdr: csv::Reader<BufReader<fs::File>> = csv::ReaderBuilder::new()
         .delimiter( delimiter_byte )
-        .double_quote(match args.quote() == &1 {
-            true => true,
-            false => false,
-        })
+        .double_quote(args.quote())
         .from_reader(bf);
     let mut columns_with_nulls: Vec<String> = Vec::new();
     let mut has_whitespace: Vec<bool> = Vec::new();
@@ -151,10 +152,7 @@ pub fn print_headers_few_lines_and_line_count(args:&Args) {
     let bf: BufReader<fs::File> = BufReader::new(file);
     let mut rdr = csv::ReaderBuilder::new()
         .delimiter(if args.delimiter() == "," { b',' } else { b'\t' })
-        .double_quote(match args.quote() == &1 {
-            true => true,
-            false => false,
-        })
+        .double_quote(args.quote())
         .from_reader(bf);
     let headers: &csv::StringRecord = rdr.headers().expect("Error reading headers");
     println!("Headers: {:?}", headers);


### PR DESCRIPTION
### Details 
- Adjust the double quote getter to return a boolean to avoid do the pattern matching when ever we use it.
- Add unit tests  to cover the newly changed parts.

### Code Snippets 

```RUST
pub fn quote(&self) -> bool {
        if &self.quote == &1 {
            return true
        } 

        false
    }
```

```RUST

#[test]
    fn test_quote_with_default_is_false() {
        let args: Args = Args::parse_from(&["sniffer", "-f", "test.csv"]);
        let result: bool = args.quote();
        assert_eq!(result, false);
    }

    #[test]
    fn test_quote_with_true_is_true() {
        let args: Args = Args::parse_from(&["sniffer", "-f", "test.csv", "-q", "1"]);
        let result: bool = args.quote();
        assert_eq!(result, true);
    }

```